### PR TITLE
Notice option

### DIFF
--- a/earl.pl
+++ b/earl.pl
@@ -119,7 +119,16 @@ sub said {
         $reply = substr($reply, 0, $maxLen) . '...';
       }
 
-      $self->reply( $args, "[ $reply ]$olde" );
+      my $message = "[ $reply ]$olde";
+      if (!defined $config{'usenotice'} || !$config{'usenotice'}) {
+        $self->reply( $args, $message );
+      }
+      else{
+        $self->notice(
+          channel => $args->{channel},
+          body =>  $message
+        );
+      }
     }
   }
 }

--- a/earl.pl
+++ b/earl.pl
@@ -36,6 +36,10 @@ sub ignore_nick {
   $self->next::method($nick);
 }
 
+sub connected {
+  print("Connected\n");
+}
+
 sub run {
   my ($self, $no_run) = @_;
 


### PR DESCRIPTION
I've added an option for using 'notice' messages.
This pull request also adds a thing that tells you when you are connected, which prevents the confusion I experienced when it said "Trying to connect to ..." but then never claimed to be connected.

I don't mind if you'd rather not have the "connected" feature, but the notice one is probably useful to others.